### PR TITLE
[torrent-stats] proposed refactor

### DIFF
--- a/src/main/java/com/frostwire/jlibtorrent/SessionManager.java
+++ b/src/main/java/com/frostwire/jlibtorrent/SessionManager.java
@@ -1038,6 +1038,9 @@ public class SessionManager {
         sb.append("&x.pe=" + hostAddress + ":" + port);
     }
 
+
+
+
     private void alertsLoop() {
         Runnable r = new Runnable() {
             @Override
@@ -1117,6 +1120,11 @@ public class SessionManager {
         Thread t = new Thread(r, "SessionManager-alertsLoop");
         t.setDaemon(true);
         t.start();
+
+    }
+
+    public TorrentStats trackStats(TorrentHandle torrentHandle, long samplingIntervalInMs, long maxHistoryInMs) {
+        return new TorrentStats(this, torrentHandle, samplingIntervalInMs, maxHistoryInMs);
     }
 
     public static final class MutableItem {
@@ -1131,4 +1139,5 @@ public class SessionManager {
         public final byte[] signature;
         public final long seq;
     }
+
 }

--- a/src/main/java/com/frostwire/jlibtorrent/SessionManager.java
+++ b/src/main/java/com/frostwire/jlibtorrent/SessionManager.java
@@ -1119,7 +1119,7 @@ public class SessionManager {
         t.start();
     }
 
-    public TorrentStats trackStats(TorrentHandle torrentHandle, long samplingIntervalInMs, long maxHistoryInMs) {
+    public TorrentStats trackTorrentStats(TorrentHandle torrentHandle, long samplingIntervalInMs, long maxHistoryInMs) {
         return new TorrentStats(this, torrentHandle, samplingIntervalInMs, maxHistoryInMs);
     }
 

--- a/src/main/java/com/frostwire/jlibtorrent/SessionManager.java
+++ b/src/main/java/com/frostwire/jlibtorrent/SessionManager.java
@@ -1038,9 +1038,6 @@ public class SessionManager {
         sb.append("&x.pe=" + hostAddress + ":" + port);
     }
 
-
-
-
     private void alertsLoop() {
         Runnable r = new Runnable() {
             @Override

--- a/src/main/java/com/frostwire/jlibtorrent/SessionManager.java
+++ b/src/main/java/com/frostwire/jlibtorrent/SessionManager.java
@@ -1117,7 +1117,6 @@ public class SessionManager {
         Thread t = new Thread(r, "SessionManager-alertsLoop");
         t.setDaemon(true);
         t.start();
-
     }
 
     public TorrentStats trackStats(TorrentHandle torrentHandle, long samplingIntervalInMs, long maxHistoryInMs) {
@@ -1136,5 +1135,4 @@ public class SessionManager {
         public final byte[] signature;
         public final long seq;
     }
-
 }

--- a/src/main/java/com/frostwire/jlibtorrent/TorrentStats.java
+++ b/src/main/java/com/frostwire/jlibtorrent/TorrentStats.java
@@ -94,13 +94,12 @@ public final class TorrentStats {
      * @return all the elements tracked by the event listener limited by the maxHistory
      */
 
-    public int[] get(Metric type, Integer... limit) {
+    public int[] get(Metric type, Integer numberElements) {
 
         Queue<Integer> resultQueue = null;
-        int numberElements = 0;
 
-        if (limit.length >= 1) {
-            numberElements = limit[0];
+        if (numberElements < 0) {
+            numberElements = 0;
         }
 
         switch (type) {

--- a/src/main/java/com/frostwire/jlibtorrent/TorrentStats.java
+++ b/src/main/java/com/frostwire/jlibtorrent/TorrentStats.java
@@ -58,16 +58,13 @@ public final class TorrentStats {
             @Override
             public void alert(Alert<?> alert) {
 
-                if (!(alert instanceof TorrentAlert<?>)) {
-                    return;
-                }
                 //if not eq to the torrentHandle return.
                 if (!((TorrentAlert<?>) alert).handle().swig().op_eq(torrentHandle.swig())) {
                     return;
                 }
 
-                //if !paused && !finished, it could be paused during the download
-                if (!torrentHandle.status().isFinished() && !torrentHandle.status().isPaused()) {
+                //if !paused, it will take both stats when uploading / downloading
+                if (!torrentHandle.status().isPaused()) {
 
                     //only true if samplingIntervalInMs
                     if ((System.currentTimeMillis() - tStart) >= samplingIntervalInMs) {
@@ -140,6 +137,7 @@ public final class TorrentStats {
      */
 
     int[] toIntArray(Queue<Integer> queue) {
+
         int[] con = new int[queue.size()];
         int i = 0;
         for (Integer e : queue) {

--- a/src/main/java/com/frostwire/jlibtorrent/TorrentStats.java
+++ b/src/main/java/com/frostwire/jlibtorrent/TorrentStats.java
@@ -22,11 +22,11 @@ public final class TorrentStats {
     private final SessionManager sessionManager;
     private final TorrentHandle torrentHandle;
     private final long samplingIntervalInMs;
-    private static final int[] STATS = {AlertType.STATS.swig()};
-    private Queue<Integer> downloadRate = new LinkedList<>();
-    private Queue<Integer> uploadRate = new LinkedList<>();
+    private final int[] STATS = {AlertType.STATS.swig()};
+    private final long MAX_SAMPLES;
+    private final Queue<Integer> downloadRate = new LinkedList<>();
+    private final Queue<Integer> uploadRate = new LinkedList<>();
     private long tStart; //for collecting sampling interval time
-    private long MAX_SAMPLES;
 
     public enum Metric {
         UploadRate,

--- a/src/main/java/com/frostwire/jlibtorrent/TorrentStats.java
+++ b/src/main/java/com/frostwire/jlibtorrent/TorrentStats.java
@@ -4,6 +4,7 @@ import com.frostwire.jlibtorrent.alerts.Alert;
 import com.frostwire.jlibtorrent.alerts.AlertType;
 import com.frostwire.jlibtorrent.alerts.BlockFinishedAlert;
 import com.frostwire.jlibtorrent.alerts.TorrentAddedAlert;
+import sun.invoke.empty.Empty;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -17,36 +18,26 @@ public final class TorrentStats {
     private TorrentHandle torrentHandle;
     private long samplingIntervalInMs;
     private long maxHistoryInMs;
-
     public static final String UPLOAD = "UPLOAD";
     public static final String DOWNLOAD = "DOWNLOAD";
-
-
-
     private Queue<Integer> downloadRate = new LinkedList<Integer>();
     private Queue<Integer> uploadRate = new LinkedList<Integer>();
-
-    //for collecting sampling interval time
-    private long tStart;
+    private long tStart; //for collecting sampling interval time
 
     public TorrentStats(final SessionManager sessionManager, TorrentHandle torrentHandle, long samplingIntervalInMs, long maxHistoryInMs) {
         this.sessionManager = sessionManager;
         this.torrentHandle = torrentHandle;
         this.samplingIntervalInMs = samplingIntervalInMs;
         this.maxHistoryInMs = maxHistoryInMs;
-        tStart = System.currentTimeMillis();
+        this.tStart = System.currentTimeMillis();
 
-        //start internal alert listener
         startAlertListener();
-
-
     }
 
 
     private void startAlertListener() {
 
         sessionManager.addListener(new AlertListener() {
-
             @Override
             public int[] types() {
                 return null;
@@ -64,28 +55,22 @@ public final class TorrentStats {
                         break;
 
                     case BLOCK_FINISHED:
-                        //only true if samplingIntervalInMs, margin of error 5-90 ms
+                        //only true if samplingIntervalInMs,as soon as I get it from the alert margin of error 5-90 ms.
                         if ((System.currentTimeMillis() - tStart) >= samplingIntervalInMs) {
                             tStart = System.currentTimeMillis();
 
-                            BlockFinishedAlert a = (BlockFinishedAlert) alert;
-                            int p = (int) (a.handle().status().progress() * 100);
-
-                            //if !paused && !finished
+                            //if !paused && !finished, it could be paused during the download
                             if (!torrentHandle.status().isFinished() && !torrentHandle.status().isPaused()) {
 
                                 downloadRate.add(torrentHandle.status().downloadRate());
                                 uploadRate.add(torrentHandle.status().uploadRate());
 
-
-                                System.out.println("Sampled time: " + downloadRate.size() * samplingIntervalInMs + " / maxHistory: "+ maxHistoryInMs);
-                                //if the sampling # exceeded the limit
-                                if(downloadRate.size() * samplingIntervalInMs > maxHistoryInMs){
+                                //if the sampling # exceeded the limit, remove head
+                                if (downloadRate.size() * samplingIntervalInMs > maxHistoryInMs) {
                                     downloadRate.poll();
                                     uploadRate.poll();
                                 }
 
-                                System.out.println("#of elements = "+ downloadRate.size());
 
                             }
 
@@ -104,9 +89,72 @@ public final class TorrentStats {
 
     //Type = DOWNLOAD / UPLOAD
     //limit = number of download speed samples or less if available
-    public int[] get(String type, int limit) {
+    public int[] get(String type) {
+        Queue<Integer> resultQueue = null;
+        int i;
 
-        return new int[1];
+        if (type.compareToIgnoreCase(this.UPLOAD) == 0)
+            resultQueue = uploadRate;
+        else if (type.compareToIgnoreCase(this.DOWNLOAD) == 0)
+            resultQueue = uploadRate;
+
+        if (!resultQueue.isEmpty()) {
+            int[] rateHistory = new int[resultQueue.size()];
+
+            //returning available items
+            i = 0;
+            for (Integer element : resultQueue) {
+                //System.out.println("element: "+element.intValue());
+                rateHistory[i] = element.intValue();
+
+                i++;
+            }
+
+            return rateHistory;
+        }
+
+        //return empty queue is empty
+        return new int[10];
+
+    }
+
+    public int[] get(String type, int limit) {
+        Queue<Integer> resultQueue = null;
+        int[] rateHistory=null;
+        int i, j;
+
+        if (type.compareToIgnoreCase(this.UPLOAD) == 0)
+            resultQueue = uploadRate;
+        else if (type.compareToIgnoreCase(this.DOWNLOAD) == 0)
+            resultQueue = uploadRate;
+
+        if (!resultQueue.isEmpty()) {
+
+            //returning available items if limit > itemList
+            if (limit >= resultQueue.size()) {
+                rateHistory = this.get(type);
+
+            } else if (limit < resultQueue.size()) {
+                rateHistory = new int[limit];
+                i = j = 0;
+
+                for (Integer element : resultQueue) {
+
+                    if (j >= resultQueue.size() - limit) {
+                        rateHistory[i] = element.intValue();
+                        i++;
+                    }
+                    j++;
+                }
+
+
+            }
+            return rateHistory;
+
+        }
+        //return empty queue is empty
+        return new int[limit];
+
     }
 
 

--- a/src/main/java/com/frostwire/jlibtorrent/TorrentStats.java
+++ b/src/main/java/com/frostwire/jlibtorrent/TorrentStats.java
@@ -1,6 +1,7 @@
 package com.frostwire.jlibtorrent;
 
 import com.frostwire.jlibtorrent.alerts.Alert;
+import com.frostwire.jlibtorrent.alerts.AlertType;
 import com.frostwire.jlibtorrent.alerts.TorrentAlert;
 
 import java.util.Arrays;
@@ -21,7 +22,7 @@ public final class TorrentStats {
     private final SessionManager sessionManager;
     private final TorrentHandle torrentHandle;
     private final long samplingIntervalInMs;
-    private final long maxHistoryInMs;
+    private static final int[] STATS = {AlertType.STATS.swig()};
     private Queue<Integer> downloadRate = new LinkedList<>();
     private Queue<Integer> uploadRate = new LinkedList<>();
     private long tStart; //for collecting sampling interval time
@@ -36,7 +37,6 @@ public final class TorrentStats {
         this.sessionManager = sessionManager;
         this.torrentHandle = torrentHandle;
         this.samplingIntervalInMs = samplingIntervalInMs;
-        this.maxHistoryInMs = maxHistoryInMs;
         this.tStart = System.currentTimeMillis();
         this.MAX_SAMPLES = maxHistoryInMs / samplingIntervalInMs;
         startAlertListener();
@@ -52,7 +52,7 @@ public final class TorrentStats {
         sessionManager.addListener(new AlertListener() {
             @Override
             public int[] types() {
-                return null;
+                return STATS;
             }
 
             @Override

--- a/src/main/java/com/frostwire/jlibtorrent/TorrentStats.java
+++ b/src/main/java/com/frostwire/jlibtorrent/TorrentStats.java
@@ -1,0 +1,113 @@
+package com.frostwire.jlibtorrent;
+
+import com.frostwire.jlibtorrent.alerts.Alert;
+import com.frostwire.jlibtorrent.alerts.AlertType;
+import com.frostwire.jlibtorrent.alerts.BlockFinishedAlert;
+import com.frostwire.jlibtorrent.alerts.TorrentAddedAlert;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.Queue;
+
+
+public final class TorrentStats {
+
+
+    private SessionManager sessionManager;
+    private TorrentHandle torrentHandle;
+    private long samplingIntervalInMs;
+    private long maxHistoryInMs;
+
+    public static final String UPLOAD = "UPLOAD";
+    public static final String DOWNLOAD = "DOWNLOAD";
+
+
+
+    private Queue<Integer> downloadRate = new LinkedList<Integer>();
+    private Queue<Integer> uploadRate = new LinkedList<Integer>();
+
+    //for collecting sampling interval time
+    private long tStart;
+
+    public TorrentStats(final SessionManager sessionManager, TorrentHandle torrentHandle, long samplingIntervalInMs, long maxHistoryInMs) {
+        this.sessionManager = sessionManager;
+        this.torrentHandle = torrentHandle;
+        this.samplingIntervalInMs = samplingIntervalInMs;
+        this.maxHistoryInMs = maxHistoryInMs;
+        tStart = System.currentTimeMillis();
+
+        //start internal alert listener
+        startAlertListener();
+
+
+    }
+
+
+    private void startAlertListener() {
+
+        sessionManager.addListener(new AlertListener() {
+
+            @Override
+            public int[] types() {
+                return null;
+            }
+
+            @Override
+            public void alert(Alert<?> alert) {
+                AlertType type = alert.type();
+
+                switch (type) {
+
+                    case TORRENT_ADDED:
+                        System.out.println("Torrent added ");
+                        ((TorrentAddedAlert) alert).handle().resume();
+                        break;
+
+                    case BLOCK_FINISHED:
+                        //only true if samplingIntervalInMs, margin of error 5-90 ms
+                        if ((System.currentTimeMillis() - tStart) >= samplingIntervalInMs) {
+                            tStart = System.currentTimeMillis();
+
+                            BlockFinishedAlert a = (BlockFinishedAlert) alert;
+                            int p = (int) (a.handle().status().progress() * 100);
+
+                            //if !paused && !finished
+                            if (!torrentHandle.status().isFinished() && !torrentHandle.status().isPaused()) {
+
+                                downloadRate.add(torrentHandle.status().downloadRate());
+                                uploadRate.add(torrentHandle.status().uploadRate());
+
+
+                                System.out.println("Sampled time: " + downloadRate.size() * samplingIntervalInMs + " / maxHistory: "+ maxHistoryInMs);
+                                //if the sampling # exceeded the limit
+                                if(downloadRate.size() * samplingIntervalInMs > maxHistoryInMs){
+                                    downloadRate.poll();
+                                    uploadRate.poll();
+                                }
+
+                                System.out.println("#of elements = "+ downloadRate.size());
+
+                            }
+
+                        }
+                        break;
+
+                    case TORRENT_FINISHED:
+                        System.out.println("Torrent finished");
+                        break;
+                }
+            }
+        });
+
+    }
+
+
+    //Type = DOWNLOAD / UPLOAD
+    //limit = number of download speed samples or less if available
+    public int[] get(String type, int limit) {
+
+        return new int[1];
+    }
+
+
+}

--- a/src/main/java/com/frostwire/jlibtorrent/TorrentStats.java
+++ b/src/main/java/com/frostwire/jlibtorrent/TorrentStats.java
@@ -1,9 +1,6 @@
 package com.frostwire.jlibtorrent;
 import com.frostwire.jlibtorrent.alerts.Alert;
-
-import java.util.ArrayList;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Queue;
 
 /**
@@ -59,7 +56,7 @@ public final class TorrentStats {
 
                     //if !paused && !finished, it could be paused during the download
                     if (!torrentHandle.status().isFinished() && !torrentHandle.status().isPaused()) {
-                        
+
                         downloadRate.add(torrentHandle.status().downloadRate());
                         uploadRate.add(torrentHandle.status().uploadRate());
 

--- a/src/main/java/com/frostwire/jlibtorrent/TorrentStats.java
+++ b/src/main/java/com/frostwire/jlibtorrent/TorrentStats.java
@@ -98,10 +98,6 @@ public final class TorrentStats {
 
         Queue<Integer> resultQueue = null;
 
-        if (numberElements < 0) {
-            numberElements = 0;
-        }
-
         switch (type) {
             case UploadRate:
                 resultQueue = uploadRate;
@@ -113,7 +109,7 @@ public final class TorrentStats {
         }
 
         if (!resultQueue.isEmpty()) {
-            if (numberElements == 0) {
+            if (numberElements <= 0) {
                 return toIntArray(resultQueue);
             } else {
                 if (numberElements >= MAX_SAMPLES || numberElements >= resultQueue.size()) {

--- a/src/main/java/com/frostwire/jlibtorrent/TorrentStats.java
+++ b/src/main/java/com/frostwire/jlibtorrent/TorrentStats.java
@@ -1,15 +1,19 @@
 package com.frostwire.jlibtorrent;
-
 import com.frostwire.jlibtorrent.alerts.Alert;
 import com.frostwire.jlibtorrent.alerts.AlertType;
-import com.frostwire.jlibtorrent.alerts.BlockFinishedAlert;
 import com.frostwire.jlibtorrent.alerts.TorrentAddedAlert;
-import sun.invoke.empty.Empty;
-
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.Queue;
 
+/**
+ * It will start an alertEvent listener to keep track of the download
+ * and upload Speed (bytes/sec). The granularity selected will depend
+ * on the speed in which the results of the speed of the Alert event
+ * listener is retrieved, which can have a delay in milliseconds calculated
+ * in avg of 1-90ms.
+ *
+ * @author haperlot
+ */
 
 public final class TorrentStats {
 
@@ -24,6 +28,7 @@ public final class TorrentStats {
     private Queue<Integer> uploadRate = new LinkedList<Integer>();
     private long tStart; //for collecting sampling interval time
 
+
     public TorrentStats(final SessionManager sessionManager, TorrentHandle torrentHandle, long samplingIntervalInMs, long maxHistoryInMs) {
         this.sessionManager = sessionManager;
         this.torrentHandle = torrentHandle;
@@ -35,6 +40,12 @@ public final class TorrentStats {
     }
 
 
+    /**
+     * It will start the alert event listener, as soon as the sampling interval
+     * meets the requested time it will save the values on queues. If the queues
+     * reach max size denoted by the maxHistory time, they will poll() the head
+     * element, in our case the oldest inserted.
+     */
     private void startAlertListener() {
 
         sessionManager.addListener(new AlertListener() {
@@ -87,8 +98,12 @@ public final class TorrentStats {
     }
 
 
-    //Type = DOWNLOAD / UPLOAD
-    //limit = number of download speed samples or less if available
+    /**
+     * Will return all available items on the queue, depending on the type selected
+     * @return all the elements tracked by the event listener limited by the maxHistor
+     * @param type type of speed (bytes/sec) data to retrieve
+     */
+
     public int[] get(String type) {
         Queue<Integer> resultQueue = null;
         int i;
@@ -104,7 +119,6 @@ public final class TorrentStats {
             //returning available items
             i = 0;
             for (Integer element : resultQueue) {
-                //System.out.println("element: "+element.intValue());
                 rateHistory[i] = element.intValue();
 
                 i++;
@@ -112,11 +126,18 @@ public final class TorrentStats {
 
             return rateHistory;
         }
-
         //return empty queue is empty
         return new int[10];
-
     }
+
+    /**
+     * Will return all available items on the queue, depending on the type selected.
+     * It will also limi the result returned.
+     * @param type type of speed (bytes/sec) data to retrieve
+     * @param limit number of results to retrieve
+     * @return all the elements tracked by the event listener limited by the maxHistory
+     */
+
 
     public int[] get(String type, int limit) {
         Queue<Integer> resultQueue = null;
@@ -154,8 +175,5 @@ public final class TorrentStats {
         }
         //return empty queue is empty
         return new int[limit];
-
     }
-
-
 }

--- a/src/test/java/com/frostwire/jlibtorrent/demo/TorrentStatsTest.java
+++ b/src/test/java/com/frostwire/jlibtorrent/demo/TorrentStatsTest.java
@@ -1,0 +1,54 @@
+package com.frostwire.jlibtorrent.demo;
+
+import com.frostwire.jlibtorrent.*;
+import com.frostwire.jlibtorrent.alerts.Alert;
+import com.frostwire.jlibtorrent.alerts.AlertType;
+import com.frostwire.jlibtorrent.alerts.BlockFinishedAlert;
+import com.frostwire.jlibtorrent.alerts.TorrentAddedAlert;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * @author haperlot
+ */
+public final class TorrentStatsTest {
+
+    public static void main(String[] args) throws Throwable {
+
+        // comment this line for a real application
+        args = new String[]{"/Users/maximiliamgierschmann/Downloads/Honey_Larochelle_Hijack_FrostClick_FrostWire_MP3_May_06_2016.torrent"};
+        File torrentFile = new File(args[0]);
+
+        final SessionManager sessionManager = new SessionManager();
+        final CountDownLatch signal = new CountDownLatch(1);
+
+        long samplingIntervalInMs = 1000; // 1 second
+        long maxHistoryInMs = 10*60*1000; // 10 minutes
+
+        //starting sessionManager & torrent download
+        sessionManager.start();
+        TorrentInfo ti = new TorrentInfo(torrentFile);
+        sessionManager.download(ti, torrentFile.getParentFile());
+
+
+        //getting the torrentHandle for the TorrentStats tracker
+        TorrentHandle torrentHandle = sessionManager.find(ti.infoHash());
+        // This creates a new TorrentStatsKeeper instance and all the internal alert listeners necessary
+        TorrentStats stats = sessionManager.trackStats(torrentHandle, samplingIntervalInMs, maxHistoryInMs);
+        // gets all the available upload speed samples (bytes/sec), in this case that'd be <= 600 elements
+        // int[] uploadSpeeds = sessionManager.get(TorrentStats.Upload);
+        // gets the last 10 available download speed samples or less if less available
+        //int[] last10DownloadSpeedSamples = stas.get(TorrentStats.Download, 10);
+
+
+        //stoping  sessionManager & torrent download
+        signal.await();
+        sessionManager.stop();
+
+
+    }
+
+
+}

--- a/src/test/java/com/frostwire/jlibtorrent/demo/TorrentStatsTest.java
+++ b/src/test/java/com/frostwire/jlibtorrent/demo/TorrentStatsTest.java
@@ -65,9 +65,9 @@ public final class TorrentStatsTest {
                 }
 
                 //gets all the available upload speed samples (bytes/sec), in this case that'd be <= 600 elements
-                int[] speedRate = stats.get(TorrentStats.Metric.DownloadRate, 15);
+                int[] speedRate = stats.getIntSamples(TorrentStats.Metric.DownloadRate);
                 if (!torrentHandle.status().isFinished()) {
-                    for (int i = 0; i < speedRate.length; i++) System.out.print(speedRate[i] + " ");
+                    for (int aSpeedRate : speedRate) System.out.print(aSpeedRate + " ");
                 }
                 System.out.println(" ");
             }

--- a/src/test/java/com/frostwire/jlibtorrent/demo/TorrentStatsTest.java
+++ b/src/test/java/com/frostwire/jlibtorrent/demo/TorrentStatsTest.java
@@ -1,17 +1,15 @@
 package com.frostwire.jlibtorrent.demo;
-
 import com.frostwire.jlibtorrent.*;
 import com.frostwire.jlibtorrent.alerts.Alert;
 import com.frostwire.jlibtorrent.alerts.AlertType;
-import com.frostwire.jlibtorrent.alerts.BlockFinishedAlert;
-import com.frostwire.jlibtorrent.alerts.TorrentAddedAlert;
-
 import java.io.File;
-import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
 
 /**
  * @author haperlot
+ *
+ * @samplingIntervalInMs the sampling interval time in milliseconds
+ * @maxHistoryInMs max history in milliseconds to be tracked
  */
 public final class TorrentStatsTest {
 
@@ -19,29 +17,27 @@ public final class TorrentStatsTest {
 
         // comment this line for a real application
         args = new String[]{"/Users/maximiliamgierschmann/Downloads/Honey_Larochelle_Hijack_FrostClick_FrostWire_MP3_May_06_2016.torrent"};
-        //args = new String[]{"/Users/maximiliamgierschmann/Downloads/47889789802D66F326A3B3238DF29BD891CEF493.torrent"};
-
         File torrentFile = new File(args[0]);
 
         final SessionManager sessionManager = new SessionManager();
         final CountDownLatch signal = new CountDownLatch(1);
-
-        long samplingIntervalInMs = 500; // 0.5 second
-        long maxHistoryInMs = 1 * 60 * 1000; // 1 minutes
 
         //starting sessionManager & torrent download
         sessionManager.start();
         TorrentInfo ti = new TorrentInfo(torrentFile);
         sessionManager.download(ti, torrentFile.getParentFile());
 
-
         //getting the torrentHandle for the TorrentStats tracker
         final TorrentHandle torrentHandle = sessionManager.find(ti.infoHash());
+
+
+        long samplingIntervalInMs = 500; // 0.5 second
+        long maxHistoryInMs = 1 * 60 * 1000; // 1 minutes
         // This creates a new TorrentStatsKeeper instance and all the internal alert listeners necessary
         final TorrentStats stats = sessionManager.trackStats(torrentHandle, samplingIntervalInMs, maxHistoryInMs);
 
 
-        //deckaring listener to check updated values
+        //declaring listener to check updated values
         sessionManager.addListener(new AlertListener() {
             @Override
             public int[] types() {
@@ -72,7 +68,7 @@ public final class TorrentStatsTest {
             }
         });
 
-        //stoping  sessionManager & torrent download
+        //stop sessionManager
         signal.await();
         sessionManager.stop();
 

--- a/src/test/java/com/frostwire/jlibtorrent/demo/TorrentStatsTest.java
+++ b/src/test/java/com/frostwire/jlibtorrent/demo/TorrentStatsTest.java
@@ -55,7 +55,7 @@ public final class TorrentStatsTest {
 
                     case BLOCK_FINISHED:
                         //gets all the available upload speed samples (bytes/sec), in this case that'd be <= 600 elements
-                        //int[] speedRate = stats.get(TorrentStats.DOWNLOAD);a
+                        //int[] speedRate = stats.get(TorrentStats.DOWNLOAD);
                         //gets the last 10 available download speed samples or less if less available
                         //int[] speedRate = stats.get(TorrentStats.DOWNLOAD, 10);
                         //int[] speedRate = stats.get(TorrentStats.DOWNLOAD, 1);

--- a/src/test/java/com/frostwire/jlibtorrent/demo/TorrentStatsTest.java
+++ b/src/test/java/com/frostwire/jlibtorrent/demo/TorrentStatsTest.java
@@ -2,6 +2,7 @@ package com.frostwire.jlibtorrent.demo;
 import com.frostwire.jlibtorrent.*;
 import com.frostwire.jlibtorrent.alerts.Alert;
 import com.frostwire.jlibtorrent.alerts.AlertType;
+import com.frostwire.jlibtorrent.alerts.TorrentAddedAlert;
 import java.io.File;
 import java.util.concurrent.CountDownLatch;
 
@@ -18,7 +19,6 @@ public final class TorrentStatsTest {
         // comment this line for a real application
         args = new String[]{"/Users/maximiliamgierschmann/Downloads/Honey_Larochelle_Hijack_FrostClick_FrostWire_MP3_May_06_2016.torrent"};
         File torrentFile = new File(args[0]);
-
         final SessionManager sessionManager = new SessionManager();
         final CountDownLatch signal = new CountDownLatch(1);
 
@@ -30,12 +30,11 @@ public final class TorrentStatsTest {
         //getting the torrentHandle for the TorrentStats tracker
         final TorrentHandle torrentHandle = sessionManager.find(ti.infoHash());
 
-
         long samplingIntervalInMs = 500; // 0.5 second
         long maxHistoryInMs = 1 * 60 * 1000; // 1 minutes
+
         // This creates a new TorrentStatsKeeper instance and all the internal alert listeners necessary
         final TorrentStats stats = sessionManager.trackStats(torrentHandle, samplingIntervalInMs, maxHistoryInMs);
-
 
         //declaring listener to check updated values
         sessionManager.addListener(new AlertListener() {
@@ -50,15 +49,17 @@ public final class TorrentStatsTest {
 
                 switch (type) {
 
+                    case TORRENT_ADDED:
+                        System.out.println("Torrent added ");
+                        ((TorrentAddedAlert) alert).handle().resume();
+
                     case BLOCK_FINISHED:
-                        // gets all the available upload speed samples (bytes/sec), in this case that'd be <= 600 elements
-                        //int[] speedRate = stats.get(TorrentStats.DOWNLOAD);
-
-                        // gets the last 10 available download speed samples or less if less available
-                        int[] speedRate = stats.get(TorrentStats.DOWNLOAD, 10);
+                        //gets all the available upload speed samples (bytes/sec), in this case that'd be <= 600 elements
+                        //int[] speedRate = stats.get(TorrentStats.DOWNLOAD);a
+                        //gets the last 10 available download speed samples or less if less available
+                        //int[] speedRate = stats.get(TorrentStats.DOWNLOAD, 10);
                         //int[] speedRate = stats.get(TorrentStats.DOWNLOAD, 1);
-                        //int[] speedRate = stats.get(TorrentStats.DOWNLOAD, 5);
-
+                        int[] speedRate = stats.get(TorrentStats.DOWNLOAD, 5);
                         System.out.println("Speeds(bytes/sec)");
                         if (!torrentHandle.status().isFinished())
                             for (int i = 0; i < speedRate.length; i++) System.out.print(speedRate[i] + " ");
@@ -67,13 +68,8 @@ public final class TorrentStatsTest {
                 }
             }
         });
-
         //stop sessionManager
         signal.await();
         sessionManager.stop();
-
-
     }
-
-
 }


### PR DESCRIPTION
  - STATS type array renamed to TYPES
  - MAX_SAMPLES doesn't need to be a long, we don't hold even a thousand.
  - downloadRate and uploadRate queues merged into a single 'samples' queue which contains Sample objects
  - New private Sample object to hold all the possible sampled data
  - All variable initialization moved to the constructor for uniformity
  - get(Metric, Integer) refactored into getIntSamples(Metric), no more boxing/unboxing, if we need another data type array we can refactor then
  - removed toIntArray() method
  - updated test to reflect changes